### PR TITLE
Compatibility with PG16 beta1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       PG: ${{ matrix.postgres-version }}
     strategy:
@@ -22,15 +22,19 @@ jobs:
         - '13'
         - '14'
         - '15'
+        - '16'
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up packages
       run: |
         set -e
 
         # add the official Ubuntu/Debian APT repository for PostgreSQL
-        sudo sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-testing main $PG\" > /etc/apt/sources.list.d/pgdg.list"
+        sudo apt-get update
+        sudo apt-get install curl ca-certificates gnupg
+        sudo sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main $PG\" > /etc/apt/sources.list.d/pgdg.list"
+        sudo sh -c "curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg"
         sudo apt-get update
 
         sudo apt-get install --assume-yes --quiet --no-install-suggests --no-install-recommends curl postgresql-common lcov libkrb5-dev


### PR DESCRIPTION

Update tests workflow
- test against pg16
- run tests on Ubuntu 22.04
- add repo key
- update checkout action's version